### PR TITLE
Send PHP errors to ratchet.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 Ratchetio.php
+.idea/*

--- a/README.md
+++ b/README.md
@@ -37,12 +37,10 @@ Installation
 	// ...
 	'errorHandler'=>array(
 		'class'=>'ext.yiiext.components.ratchetio.RatchetioErrorHandler',
-		'phpErrorsToRatchetio' => true,
 		// ...
 	),
 ),
 ```
-Set phpErrorsToRatchetio param in errorHandler component if you want send PHP errors to ratchet.io.
 
 You can also pass some additional ratchet.io options in the component config:
 `environment`, `branch`, `maxErrno`, `baseApiUrl` etc.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Installation
 3. Adjust `main.php` config to preload the component:
 
 ```php
-`'preload'=>array('log', 'ratchetio'),`
+'preload'=>array('log', 'ratchetio'),
 ```
 
 4. Set `RatchetioErrorHandler` as error handler:
@@ -37,10 +37,12 @@ Installation
 	// ...
 	'errorHandler'=>array(
 		'class'=>'ext.yiiext.components.ratchetio.RatchetioErrorHandler',
+		'phpErrorsToRatchetio' => true,
 		// ...
 	),
 ),
 ```
+Set phpErrorsToRatchetio param in errorHandler component if you want send PHP errors to ratchet.io.
 
 You can also pass some additional ratchet.io options in the component config:
 `environment`, `branch`, `maxErrno`, `baseApiUrl` etc.

--- a/RatchetioErrorHandler.php
+++ b/RatchetioErrorHandler.php
@@ -3,29 +3,29 @@ require_once 'ratchetio.php';
 
 class RatchetioErrorHandler extends CErrorHandler
 {
-    /**
-     * Send PHP Errors to Ratchetio
-     *
-     * @var bool
-     */
-    public $phpErrorsToRatchetio = false;
+	/**
+	 * Send PHP Errors to Ratchetio
+	 *
+	 * @var bool
+	 */
+	public $phpErrorsToRatchetio = false;
 
-    protected function handleException($exception)
-    {
-        $ignored = ($exception instanceof CHttpException && $exception->statusCode == 404);
-        if (!$ignored) {
-            Ratchetio::report_exception($exception);
-        }
-        parent::handleException($exception);
-    }
+	protected function handleException($exception)
+	{
+		$ignored = ($exception instanceof CHttpException && $exception->statusCode == 404);
+		if (!$ignored) {
+			Ratchetio::report_exception($exception);
+		}
+		parent::handleException($exception);
+	}
 
 
-    protected function handleError($event)
-    {
-        if ($this->phpErrorsToRatchetio) {
-            Ratchetio::report_php_error($event->code, $event->message, $event->file, $event->line);
-        }
+	protected function handleError($event)
+	{
+		if ($this->phpErrorsToRatchetio) {
+			Ratchetio::report_php_error($event->code, $event->message, $event->file, $event->line);
+		}
 
-        parent::handleError($event);
-    }
+		parent::handleError($event);
+	}
 }

--- a/RatchetioErrorHandler.php
+++ b/RatchetioErrorHandler.php
@@ -3,12 +3,29 @@ require_once 'ratchetio.php';
 
 class RatchetioErrorHandler extends CErrorHandler
 {
-  protected function handleException($exception)
-  {
-    $ignored = ($exception instanceof CHttpException && $exception->statusCode == 404);
-    if (!$ignored) {
-      Ratchetio::report_exception($exception);
+    /**
+     * Send PHP Errors to Ratchetio
+     *
+     * @var bool
+     */
+    public $phpErrorsToRatchetio = false;
+
+    protected function handleException($exception)
+    {
+        $ignored = ($exception instanceof CHttpException && $exception->statusCode == 404);
+        if (!$ignored) {
+            Ratchetio::report_exception($exception);
+        }
+        parent::handleException($exception);
     }
-    parent::handleException($exception);
-  }
+
+
+    protected function handleError($event)
+    {
+        if ($this->phpErrorsToRatchetio) {
+            Ratchetio::report_php_error($event->code, $event->message, $event->file, $event->line);
+        }
+
+        parent::handleError($event);
+    }
 }

--- a/RatchetioErrorHandler.php
+++ b/RatchetioErrorHandler.php
@@ -3,13 +3,6 @@ require_once 'ratchetio.php';
 
 class RatchetioErrorHandler extends CErrorHandler
 {
-	/**
-	 * Send PHP Errors to Ratchetio
-	 *
-	 * @var bool
-	 */
-	public $phpErrorsToRatchetio = false;
-
 	protected function handleException($exception)
 	{
 		$ignored = ($exception instanceof CHttpException && $exception->statusCode == 404);
@@ -22,9 +15,7 @@ class RatchetioErrorHandler extends CErrorHandler
 
 	protected function handleError($event)
 	{
-		if ($this->phpErrorsToRatchetio) {
-			Ratchetio::report_php_error($event->code, $event->message, $event->file, $event->line);
-		}
+		Ratchetio::report_php_error($event->code, $event->message, $event->file, $event->line);
 
 		parent::handleError($event);
 	}


### PR DESCRIPTION
For some applications is also important handling php errors.
I add code to RatchetioErrorHandler, by default php errors is disabled, by setting phpErrorsToRatchetio to true its enable.
